### PR TITLE
Enum to int

### DIFF
--- a/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/Bone.cs
+++ b/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/Bone.cs
@@ -460,7 +460,7 @@ __scaling = null;
             );
         }
 
-        public void translate(Vector3 vec, Space space = null, AbstractMesh mesh = null)
+        public void translate(Vector3 vec, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -470,7 +470,7 @@ __scaling = null;
             );
         }
 
-        public void setPosition(Vector3 position, Space space = null, AbstractMesh mesh = null)
+        public void setPosition(Vector3 position, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -531,7 +531,7 @@ __scaling = null;
             );
         }
 
-        public void setYawPitchRoll(decimal yaw, decimal pitch, decimal roll, Space space = null, AbstractMesh mesh = null)
+        public void setYawPitchRoll(decimal yaw, decimal pitch, decimal roll, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -541,7 +541,7 @@ __scaling = null;
             );
         }
 
-        public void rotate(Vector3 axis, decimal amount, Space space = null, AbstractMesh mesh = null)
+        public void rotate(Vector3 axis, decimal amount, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -551,7 +551,7 @@ __scaling = null;
             );
         }
 
-        public void setAxisAngle(Vector3 axis, decimal angle, Space space = null, AbstractMesh mesh = null)
+        public void setAxisAngle(Vector3 axis, decimal angle, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -561,7 +561,7 @@ __scaling = null;
             );
         }
 
-        public void setRotation(Vector3 rotation, Space space = null, AbstractMesh mesh = null)
+        public void setRotation(Vector3 rotation, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -571,7 +571,7 @@ __scaling = null;
             );
         }
 
-        public void setRotationQuaternion(Quaternion quat, Space space = null, AbstractMesh mesh = null)
+        public void setRotationQuaternion(Quaternion quat, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -581,7 +581,7 @@ __scaling = null;
             );
         }
 
-        public void setRotationMatrix(Matrix rotMat, Space space = null, AbstractMesh mesh = null)
+        public void setRotationMatrix(Matrix rotMat, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -591,7 +591,7 @@ __scaling = null;
             );
         }
 
-        public Vector3 getPosition(Space space = null, AbstractMesh mesh = null)
+        public Vector3 getPosition(System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             return EventHorizonBlazorInterop.FuncClass<Vector3>(
                 entity => new Vector3() { ___guid = entity.___guid },
@@ -602,7 +602,7 @@ __scaling = null;
             );
         }
 
-        public void getPositionToRef(AbstractMesh mesh, Vector3 result, Space space = null)
+        public void getPositionToRef(AbstractMesh mesh, Vector3 result, System.Nullable<int> space = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -664,7 +664,7 @@ __scaling = null;
             );
         }
 
-        public Vector3 getRotation(Space space = null, AbstractMesh mesh = null)
+        public Vector3 getRotation(System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             return EventHorizonBlazorInterop.FuncClass<Vector3>(
                 entity => new Vector3() { ___guid = entity.___guid },
@@ -675,7 +675,7 @@ __scaling = null;
             );
         }
 
-        public void getRotationToRef(Vector3 result, Space space = null, AbstractMesh mesh = null)
+        public void getRotationToRef(Vector3 result, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -685,7 +685,7 @@ __scaling = null;
             );
         }
 
-        public Quaternion getRotationQuaternion(Space space = null, AbstractMesh mesh = null)
+        public Quaternion getRotationQuaternion(System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             return EventHorizonBlazorInterop.FuncClass<Quaternion>(
                 entity => new Quaternion() { ___guid = entity.___guid },
@@ -696,7 +696,7 @@ __scaling = null;
             );
         }
 
-        public void getRotationQuaternionToRef(Quaternion result, Space space = null, AbstractMesh mesh = null)
+        public void getRotationQuaternionToRef(Quaternion result, System.Nullable<int> space = null, AbstractMesh mesh = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -706,7 +706,7 @@ __scaling = null;
             );
         }
 
-        public Matrix getRotationMatrix(AbstractMesh mesh, Space space = null)
+        public Matrix getRotationMatrix(AbstractMesh mesh, System.Nullable<int> space = null)
         {
             return EventHorizonBlazorInterop.FuncClass<Matrix>(
                 entity => new Matrix() { ___guid = entity.___guid },
@@ -717,7 +717,7 @@ __scaling = null;
             );
         }
 
-        public void getRotationMatrixToRef(AbstractMesh mesh, Matrix result, Space space = null)
+        public void getRotationMatrixToRef(AbstractMesh mesh, Matrix result, System.Nullable<int> space = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 

--- a/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/GUI/TextBlock.cs
+++ b/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/GUI/TextBlock.cs
@@ -60,27 +60,19 @@ namespace BabylonJS.GUI
             }
         }
 
-        private TextWrapping __textWrapping;
-        public TextWrapping textWrapping
+        
+        public int textWrapping
         {
             get
             {
-            if(__textWrapping == null)
-            {
-                __textWrapping = EventHorizonBlazorInterop.GetClass<TextWrapping>(
+            return EventHorizonBlazorInterop.Get<int>(
                     this.___guid,
-                    "textWrapping",
-                    (entity) =>
-                    {
-                        return new TextWrapping() { ___guid = entity.___guid };
-                    }
+                    "textWrapping"
                 );
-            }
-            return __textWrapping;
             }
             set
             {
-__textWrapping = null;
+
                 EventHorizonBlazorInterop.Set(
                     this.___guid,
                     "textWrapping",

--- a/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/IAnimationKey.cs
+++ b/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/IAnimationKey.cs
@@ -115,27 +115,19 @@ namespace BabylonJS
             }
         }
 
-        private AnimationKeyInterpolation __interpolation;
-        public AnimationKeyInterpolation interpolation
+        
+        public int interpolation
         {
             get
             {
-            if(__interpolation == null)
-            {
-                __interpolation = EventHorizonBlazorInterop.GetClass<AnimationKeyInterpolation>(
+            return EventHorizonBlazorInterop.Get<int>(
                     this.___guid,
-                    "interpolation",
-                    (entity) =>
-                    {
-                        return new AnimationKeyInterpolation() { ___guid = entity.___guid };
-                    }
+                    "interpolation"
                 );
-            }
-            return __interpolation;
             }
             set
             {
-__interpolation = null;
+
                 EventHorizonBlazorInterop.Set(
                     this.___guid,
                     "interpolation",

--- a/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/IInspectable.cs
+++ b/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/IInspectable.cs
@@ -73,27 +73,19 @@ namespace BabylonJS
             }
         }
 
-        private InspectableType __type;
-        public InspectableType type
+        
+        public int type
         {
             get
             {
-            if(__type == null)
-            {
-                __type = EventHorizonBlazorInterop.GetClass<InspectableType>(
+            return EventHorizonBlazorInterop.Get<int>(
                     this.___guid,
-                    "type",
-                    (entity) =>
-                    {
-                        return new InspectableType() { ___guid = entity.___guid };
-                    }
+                    "type"
                 );
-            }
-            return __type;
             }
             set
             {
-__type = null;
+
                 EventHorizonBlazorInterop.Set(
                     this.___guid,
                     "type",

--- a/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/InternalTexture.cs
+++ b/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/InternalTexture.cs
@@ -27,23 +27,15 @@ namespace BabylonJS
         #endregion
 
         #region Accessors
-        private InternalTextureSource __source;
-        public InternalTextureSource source
+        
+        public int source
         {
             get
             {
-            if(__source == null)
-            {
-                __source = EventHorizonBlazorInterop.GetClass<InternalTextureSource>(
+            return EventHorizonBlazorInterop.Get<int>(
                     this.___guid,
-                    "source",
-                    (entity) =>
-                    {
-                        return new InternalTextureSource() { ___guid = entity.___guid };
-                    }
+                    "source"
                 );
-            }
-            return __source;
             }
         }
         #endregion
@@ -468,7 +460,7 @@ __onLoadedObservable = null;
         }
 
         public InternalTexture(
-            ThinEngine engine, InternalTextureSource source, System.Nullable<bool> delayAllocation = null
+            ThinEngine engine, int source, System.Nullable<bool> delayAllocation = null
         )
         {
             var entity = EventHorizonBlazorInterop.New(

--- a/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/SceneLoader.cs
+++ b/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/SceneLoader.cs
@@ -295,7 +295,7 @@ __OnPluginActivatedObservable = null;
             );
         }
 
-        public static void ImportAnimations(string rootUrl, string sceneFilename = null, Scene scene = null, System.Nullable<bool> overwriteAnimations = null, SceneLoaderAnimationGroupLoadingMode animationGroupLoadingMode = null, ActionCallback<CachedEntity> targetConverter = null, ActionCallback<Scene> onSuccess = null, ActionCallback<SceneLoaderProgressEvent> onProgress = null, ActionCallback<Scene, string, CachedEntity> onError = null)
+        public static void ImportAnimations(string rootUrl, string sceneFilename = null, Scene scene = null, System.Nullable<bool> overwriteAnimations = null, System.Nullable<int> animationGroupLoadingMode = null, ActionCallback<CachedEntity> targetConverter = null, ActionCallback<Scene> onSuccess = null, ActionCallback<SceneLoaderProgressEvent> onProgress = null, ActionCallback<Scene, string, CachedEntity> onError = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 
@@ -305,7 +305,7 @@ __OnPluginActivatedObservable = null;
             );
         }
 
-        public static void ImportAnimationsAsync(string rootUrl, string sceneFilename = null, Scene scene = null, System.Nullable<bool> overwriteAnimations = null, SceneLoaderAnimationGroupLoadingMode animationGroupLoadingMode = null, ActionCallback<CachedEntity> targetConverter = null, ActionCallback<Scene> onSuccess = null, ActionCallback<SceneLoaderProgressEvent> onProgress = null, ActionCallback<Scene, string, CachedEntity> onError = null)
+        public static void ImportAnimationsAsync(string rootUrl, string sceneFilename = null, Scene scene = null, System.Nullable<bool> overwriteAnimations = null, System.Nullable<int> animationGroupLoadingMode = null, ActionCallback<CachedEntity> targetConverter = null, ActionCallback<Scene> onSuccess = null, ActionCallback<SceneLoaderProgressEvent> onProgress = null, ActionCallback<Scene, string, CachedEntity> onError = null)
         {
             EventHorizonBlazorInterop.Func<CachedEntity>(
                 new object[] 

--- a/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/TransformNode.cs
+++ b/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/TransformNode.cs
@@ -764,7 +764,7 @@ __onAfterWorldMatrixUpdateObservable = null;
             );
         }
 
-        public TransformNode lookAt(Vector3 targetPoint, System.Nullable<decimal> yawCor = null, System.Nullable<decimal> pitchCor = null, System.Nullable<decimal> rollCor = null, Space space = null)
+        public TransformNode lookAt(Vector3 targetPoint, System.Nullable<decimal> yawCor = null, System.Nullable<decimal> pitchCor = null, System.Nullable<decimal> rollCor = null, System.Nullable<int> space = null)
         {
             return EventHorizonBlazorInterop.FuncClass<TransformNode>(
                 entity => new TransformNode() { ___guid = entity.___guid },
@@ -808,7 +808,7 @@ __onAfterWorldMatrixUpdateObservable = null;
             );
         }
 
-        public TransformNode setPivotPoint(Vector3 point, Space space = null)
+        public TransformNode setPivotPoint(Vector3 point, System.Nullable<int> space = null)
         {
             return EventHorizonBlazorInterop.FuncClass<TransformNode>(
                 entity => new TransformNode() { ___guid = entity.___guid },
@@ -896,7 +896,7 @@ __onAfterWorldMatrixUpdateObservable = null;
             );
         }
 
-        public TransformNode rotate(Vector3 axis, decimal amount, Space space = null)
+        public TransformNode rotate(Vector3 axis, decimal amount, System.Nullable<int> space = null)
         {
             return EventHorizonBlazorInterop.FuncClass<TransformNode>(
                 entity => new TransformNode() { ___guid = entity.___guid },
@@ -918,7 +918,7 @@ __onAfterWorldMatrixUpdateObservable = null;
             );
         }
 
-        public TransformNode translate(Vector3 axis, decimal distance, Space space = null)
+        public TransformNode translate(Vector3 axis, decimal distance, System.Nullable<int> space = null)
         {
             return EventHorizonBlazorInterop.FuncClass<TransformNode>(
                 entity => new TransformNode() { ___guid = entity.___guid },

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator.Model/Statements/TypeStatement.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator.Model/Statements/TypeStatement.cs
@@ -15,6 +15,7 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Model.Statements
         public bool IsLiteral { get; set; }
         public bool IsModifier { get; set; }
         public bool IsInterface { get; set; }
+        public bool IsEnum { get; set; }
 
         public override string ToString()
         {
@@ -22,6 +23,7 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Model.Statements
             var nullable = IsNullable ? "?" : string.Empty;
             var modifier = IsModifier ? "(M)" : string.Empty;
             var interfaceString = IsInterface ? "(I)" : string.Empty;
+            var enumString = IsEnum ? $"(E)" : string.Empty;
             var arguments = string.Join(
                 ", ",
                 Arguments.Select(generic => generic.ToString())
@@ -33,7 +35,7 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Model.Statements
             );
             var generics = GenericTypes.Any() ? $"<{genericsJoined}>" : string.Empty;
 
-            return $"{action} {modifier}{interfaceString}{Name}{generics}{array}{nullable}";
+            return $"{action} {enumString}{modifier}{interfaceString}{Name}{generics}{array}{nullable}";
         }
     }
 }

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/GenerateSource.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/GenerateSource.cs
@@ -5,7 +5,6 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator
     using System.IO;
     using System.Linq;
     using System.Text;
-    using EventHorizon.Blazor.TypeScript.Interop.Generator.Formatter;
     using EventHorizon.Blazor.TypeScript.Interop.Generator.Identifiers;
     using EventHorizon.Blazor.TypeScript.Interop.Generator.Logging;
     using EventHorizon.Blazor.TypeScript.Interop.Generator.Model;
@@ -19,6 +18,7 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator
         public static void DisableCache()
         {
             InterfaceResponseTypeIdentifier.DisableCache();
+            EnumTypeIdentifier.DisableCache();
         }
 
         public bool Run(

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Identifiers/EnumTypeIdentifier.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Identifiers/EnumTypeIdentifier.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Sdcb.TypeScript;
+using Sdcb.TypeScript.TsTypes;
+
+namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Identifiers
+{
+    public interface IEnumTypeIdentifier
+    {
+        bool Identify(
+            string identifierString,
+            TypeScriptAST ast
+        );
+    }
+
+    public static class EnumTypeIdentifier
+    {
+
+        private static IEnumTypeIdentifier CACHED = new EnumTypeIdentifierCached();
+        private static IEnumTypeIdentifier NOT_CACHED = new EnumTypeIdentifierNotCached();
+        private static IEnumTypeIdentifier ACTIVE = CACHED;
+
+        public static void DisableCache()
+        {
+            ACTIVE = NOT_CACHED;
+        }
+
+        public static bool Identify(
+            string identifierString,
+            TypeScriptAST ast
+        )
+        {
+            return ACTIVE.Identify(
+                identifierString,
+                ast
+            );
+        }
+    }
+
+    public class EnumTypeIdentifierNotCached
+        : IEnumTypeIdentifier
+    {
+        public virtual bool Identify(
+            string identifierString,
+            TypeScriptAST ast
+        )
+        {
+            var hasEnumDeclarations = ast.RootNode.OfKind(
+                SyntaxKind.EnumDeclaration
+            ).Any(
+                child => child.IdentifierStr == identifierString
+            );
+            return hasEnumDeclarations;
+        }
+    }
+
+    public class EnumTypeIdentifierCached
+        : EnumTypeIdentifierNotCached
+    {
+        private readonly Dictionary<string, bool> _cache = new Dictionary<string, bool>();
+
+        public override bool Identify(
+            string identifierString,
+            TypeScriptAST ast
+        )
+        {
+            if (_cache.TryGetValue(identifierString, out var value))
+            {
+                return value;
+            }
+            var response = base.Identify(
+                identifierString,
+                ast
+            );
+            if (identifierString != null)
+            {
+                _cache[identifierString] = response;
+            }
+            return response;
+        }
+    }
+}

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Identifiers/GenericTypeIdentifier.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Identifiers/GenericTypeIdentifier.cs
@@ -187,6 +187,10 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Identifiers
                     typeIdentifier,
                     ast
                 ),
+                IsEnum = EnumTypeIdentifier.Identify(
+                    typeIdentifier,
+                    ast
+                ),
                 GenericTypes = genericTypes,
                 Arguments = ArgumentIdentifier.Identify(
                     node,

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/AccessorsSectionWriter.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/AccessorsSectionWriter.cs
@@ -35,6 +35,8 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Writers
                 var isArray = ArrayResponseIdentifier.Identify(
                     accessor.Type
                 );
+                var isEnum = accessor.Type.IsEnum;
+
                 var template = templates.Accessor;
                 var propertyGetterResultType = templates.InteropGet;
                 var root = "this.___guid";
@@ -72,7 +74,11 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Writers
                     }
                 }
 
-                if (isClassResponse && isArray)
+                if(isEnum)
+                {
+                    propertyGetterResultType = templates.InteropGet;
+                }
+                else if (isClassResponse && isArray)
                 {
                     propertyGetterResultType = templates.InteropGetArrayClass;
                 }

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/ArgumentWriter.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/ArgumentWriter.cs
@@ -63,28 +63,35 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Writers
             if (typeStatement.IsNullable)
             {
                 var genericType = typeStatement.GenericTypes.First();
-                if (ClassIdentifier.Identify(
-                    usedClassNames,
-                    genericType.Name
-                ) || genericType.IsNullable
-                    || genericType.IsArray
-                    || genericType.IsModifier
-                    || genericType.IsAction
-                    || genericType.Name == GenerationIdentifiedTypes.String
-                    || genericType.Name == GenerationIdentifiedTypes.CachedEntity)
+
+                if (!genericType.IsEnum
+                    && (ClassIdentifier.Identify(
+                        usedClassNames,
+                        genericType.Name
+                    ) || genericType.IsNullable
+                        || genericType.IsArray
+                        || genericType.IsModifier
+                        || genericType.IsAction
+                        || genericType.Name == GenerationIdentifiedTypes.String
+                        || genericType.Name == GenerationIdentifiedTypes.CachedEntity
+                    )
+                )
                 {
                     argumentsTemplate = "[[TYPE]][[IS_ARRAY]][[NAME]][[DEFAULT_VALUE]]";
                 }
             }
-            else if (ClassIdentifier.Identify(
-                usedClassNames,
-                typeStatement.Name
-            ) || typeStatement.IsNullable
-                || typeStatement.IsArray
-                || typeStatement.IsModifier
-                || typeStatement.IsAction
-                || typeStatement.Name == GenerationIdentifiedTypes.String
-                || typeStatement.Name == GenerationIdentifiedTypes.CachedEntity)
+            else if (!typeStatement.IsEnum 
+                && (ClassIdentifier.Identify(
+                    usedClassNames,
+                    typeStatement.Name
+                ) || typeStatement.IsNullable
+                    || typeStatement.IsArray
+                    || typeStatement.IsModifier
+                    || typeStatement.IsAction
+                    || typeStatement.Name == GenerationIdentifiedTypes.String
+                    || typeStatement.Name == GenerationIdentifiedTypes.CachedEntity
+                )
+            )
             {
                 argumentsTemplate = "[[TYPE]][[IS_ARRAY]][[NAME]][[DEFAULT_VALUE]]";
             }

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/MethodsSectionWriter.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/MethodsSectionWriter.cs
@@ -45,6 +45,7 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Writers
                 var isNotSupported = NotSupportedIdentifier.Identify(
                     method
                 );
+                var isEnum = method.Type.IsEnum;
                 var isAction = method.Type.Name == GenerationIdentifiedTypes.Action
                     || (method.Arguments.Take(1).Any(a => a.Type.IsAction));
 
@@ -160,7 +161,11 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Writers
                     }
                 }
 
-                if (isClassResponse && isArray)
+                if (isEnum)
+                {
+                    returnTypeContent = templates.InteropFunc;
+                }
+                else if (isClassResponse && isArray)
                 {
                     returnTypeContent = templates.InteropFuncArrayClass;
                 }
@@ -172,7 +177,6 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Writers
                 {
                     returnTypeContent = templates.InteropFuncArray;
                 }
-
 
                 if (method.IsStatic)
                 {

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/PropertiesSectionWriter.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/PropertiesSectionWriter.cs
@@ -38,6 +38,7 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Writers
                 var isNotSupported = NotSupportedIdentifier.Identify(
                     property
                 );
+                var isEnum = property.Type.IsEnum;
 
                 var template = templates.AccessorWithSetter;
                 var propertyGetterResultType = templates.InteropGet;
@@ -77,7 +78,11 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Writers
                     }
                 }
 
-                if (isClassResponse && isArray)
+                if (isEnum)
+                {
+                    propertyGetterResultType = templates.InteropGet;
+                }
+                else if (isClassResponse && isArray)
                 {
                     propertyGetterResultType = templates.InteropGetArrayClass;
                 }

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/TypeStatementWriter.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Writers/TypeStatementWriter.cs
@@ -75,6 +75,13 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Writers
                     template = actionVoidTemplate;
                 }
             }
+            if(type.IsEnum)
+            {
+                template = template.Replace(
+                    "[[NAME]]",
+                    "int"
+                );
+            }
 
             return template.Replace(
                 "[[NAME]]",

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumAccessor.Expected.txt
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumAccessor.Expected.txt
@@ -1,0 +1,73 @@
+/// Generated - Do Not Edit
+namespace Static.Class
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
+    using EventHorizon.Blazor.Interop;
+    using EventHorizon.Blazor.Interop.Callbacks;
+    using Microsoft.JSInterop;
+
+    
+    
+    [JsonConverter(typeof(CachedEntityConverter<ExampleClass>))]
+    public class ExampleClass : CachedEntityObject
+    {
+        #region Static Accessors
+
+        #endregion
+
+        #region Static Properties
+
+        #endregion
+
+        #region Static Methods
+
+        #endregion
+
+        #region Accessors
+        
+        public int enumAccessor
+        {
+            get
+            {
+            return EventHorizonBlazorInterop.Get<int>(
+                    this.___guid,
+                    "enumAccessor"
+                );
+            }
+            set
+            {
+
+                EventHorizonBlazorInterop.Set(
+                    this.___guid,
+                    "enumAccessor",
+                    value
+                );
+            }
+        }
+        #endregion
+
+        #region Properties
+
+        #endregion
+        
+        #region Constructor
+        public ExampleClass() : base() { } 
+
+        public ExampleClass(
+            ICachedEntity entity
+        ) : base(entity)
+        {
+            ___guid = entity.___guid;
+        }
+
+
+        #endregion
+
+        #region Methods
+
+        #endregion
+    }
+}

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumAccessor.ts
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumAccessor.ts
@@ -1,0 +1,10 @@
+declare module Static.Class {
+    enum AccessorEnum {
+        VALUE = 0,
+    }
+
+    export class ExampleClass {
+        get enumAccessor(): AccessorEnum;
+        set enumAccessor(value: AccessorEnum);
+    }
+}

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumArgument.Expected.txt
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumArgument.Expected.txt
@@ -1,0 +1,82 @@
+/// Generated - Do Not Edit
+namespace Static.Class
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
+    using EventHorizon.Blazor.Interop;
+    using EventHorizon.Blazor.Interop.Callbacks;
+    using Microsoft.JSInterop;
+
+    
+    
+    [JsonConverter(typeof(CachedEntityConverter<ExampleClass>))]
+    public class ExampleClass : CachedEntityObject
+    {
+        #region Static Accessors
+
+        #endregion
+
+        #region Static Properties
+
+        #endregion
+
+        #region Static Methods
+
+        #endregion
+
+        #region Accessors
+
+        #endregion
+
+        #region Properties
+
+        #endregion
+        
+        #region Constructor
+        public ExampleClass() : base() { } 
+
+        public ExampleClass(
+            ICachedEntity entity
+        ) : base(entity)
+        {
+            ___guid = entity.___guid;
+        }
+
+
+        #endregion
+
+        #region Methods
+        public void enumFunction(int enumArgument)
+        {
+            EventHorizonBlazorInterop.Func<CachedEntity>(
+                new object[] 
+                {
+                    new string[] { this.___guid, "enumFunction" }, enumArgument
+                }
+            );
+        }
+
+        public void enumOptional(System.Nullable<int> enumArgument = null)
+        {
+            EventHorizonBlazorInterop.Func<CachedEntity>(
+                new object[] 
+                {
+                    new string[] { this.___guid, "enumOptional" }, enumArgument
+                }
+            );
+        }
+
+        public int enumReponse()
+        {
+            return EventHorizonBlazorInterop.Func<int>(
+                new object[] 
+                {
+                    new string[] { this.___guid, "enumReponse" }
+                }
+            );
+        }
+        #endregion
+    }
+}

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumArgument.ts
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumArgument.ts
@@ -1,0 +1,11 @@
+declare module Static.Class {
+    enum ExampleEnum {
+        VALUE = 0,
+    }
+
+    export class ExampleClass {
+        enumFunction(enumArgument: ExampleEnum): void;
+        enumOptional(enumArgument?: ExampleEnum): void;
+        enumReponse(): ExampleEnum;
+    }
+}

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumProperty.Expected.txt
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumProperty.Expected.txt
@@ -1,0 +1,73 @@
+/// Generated - Do Not Edit
+namespace Static.Class
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
+    using EventHorizon.Blazor.Interop;
+    using EventHorizon.Blazor.Interop.Callbacks;
+    using Microsoft.JSInterop;
+
+    
+    
+    [JsonConverter(typeof(CachedEntityConverter<ExampleClass>))]
+    public class ExampleClass : CachedEntityObject
+    {
+        #region Static Accessors
+
+        #endregion
+
+        #region Static Properties
+
+        #endregion
+
+        #region Static Methods
+
+        #endregion
+
+        #region Accessors
+
+        #endregion
+
+        #region Properties
+        
+        public int enumProperty
+        {
+            get
+            {
+            return EventHorizonBlazorInterop.Get<int>(
+                    this.___guid,
+                    "enumProperty"
+                );
+            }
+            set
+            {
+
+                EventHorizonBlazorInterop.Set(
+                    this.___guid,
+                    "enumProperty",
+                    value
+                );
+            }
+        }
+        #endregion
+        
+        #region Constructor
+        public ExampleClass() : base() { } 
+
+        public ExampleClass(
+            ICachedEntity entity
+        ) : base(entity)
+        {
+            ___guid = entity.___guid;
+        }
+
+
+        #endregion
+
+        #region Methods
+
+        #endregion
+    }
+}

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumProperty.ts
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/Enums/EnumProperty.ts
@@ -1,0 +1,9 @@
+declare module Static.Class {
+    enum PropertyEnum {
+        VALUE = 0,
+    }
+
+    export class ExampleClass {
+        enumProperty: PropertyEnum;
+    }
+}

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/StringGenerationTests.cs
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/GenerateClassStatementStringTests/StringGenerationTests.cs
@@ -247,5 +247,20 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Tests.GenerateClassSt
             },
             expectedFile
         );
+
+        [Theory(DisplayName = "Enums")]
+        [Trait("Category", "StringGeneration.Enum")]
+        [InlineData("EnumAccessor.ts", "Enums", "EnumAccessor.Expected.txt")]
+        [InlineData("EnumArgument.ts", "Enums", "EnumArgument.Expected.txt")]
+        [InlineData("EnumProperty.ts", "Enums", "EnumProperty.Expected.txt")]
+        public void ShouldGenerateEnumScenarioStrings(
+            string sourceFile,
+            string rootPath,
+            string expectedFile
+        ) => ValidateGenerateStrings(
+            rootPath,
+            sourceFile,
+            expectedFile
+        );
     }
 }

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/Identifiers/EnumTypeIdentifierTests.cs
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/Identifiers/EnumTypeIdentifierTests.cs
@@ -1,0 +1,91 @@
+namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Tests.Identifiers
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using EventHorizon.Blazor.TypeScript.Interop.Generator.Identifiers;
+    using EventHorizon.Blazor.TypeScript.Interop.Generator.Tests.GenerateClassStatementStringTests;
+    using FluentAssertions;
+    using Sdcb.TypeScript;
+    using Xunit;
+
+    public class EnumTypeIdentifierTests
+    {
+        [Fact]
+        [Trait("Category", "EnumTypeIdentifier.NotCached.StandardUsage")]
+        public void ShouldReturnExpectedIdentificationOfEnumWhenUsingNotCachedInstance()
+        {
+            // Given
+            var expected = true;
+            var enumIdentifierString = "EnumExport";
+
+            var sourceFile = "enum.ts";
+            var source = File.ReadAllText($"./SourceFiles/{sourceFile}");
+            var ast = new TypeScriptAST(source, sourceFile);
+
+            // When
+            var notCachedEnumIdentifier = new EnumTypeIdentifierNotCached();
+            var actual = notCachedEnumIdentifier.Identify(
+                enumIdentifierString,
+                ast
+            );
+
+            // Then
+            actual.Should()
+                .Be(expected);
+        }
+
+        [Fact]
+        [Trait("Category", "EnumTypeIdentifier.Cached.StandardUsage")]
+        public void ShouldReturnExpectedIdentificationOfEnumWhenUsingCachedInstance()
+        {
+            // Given
+            var expected = true;
+            var enumIdentifierString = "EnumExport";
+
+            var sourceFile = "enum.ts";
+            var source = File.ReadAllText($"./SourceFiles/{sourceFile}");
+            var ast = new TypeScriptAST(source, sourceFile);
+
+            // When
+            var notCachedEnumIdentifier = new EnumTypeIdentifierCached();
+            var actual = notCachedEnumIdentifier.Identify(
+                enumIdentifierString,
+                ast
+            );
+
+            // Then
+            actual.Should()
+                .Be(expected);
+        }
+
+        [Fact]
+        [Trait("Category", "EnumTypeIdentifier.Cached.MultipleCalls")]
+        public void ShouldReturnExpectedIdentificationOfEnumWhenCalledMultipleTimes()
+        {
+            // Given
+            var enumIdentifierString = "EnumExport";
+
+            var sourceFile = "enum.ts";
+            var source = File.ReadAllText($"./SourceFiles/{sourceFile}");
+            var ast = new TypeScriptAST(source, sourceFile);
+
+            // When
+            var notCachedEnumIdentifier = new EnumTypeIdentifierCached();
+            // First Identify
+            notCachedEnumIdentifier.Identify(
+                enumIdentifierString,
+                ast
+            ).Should() // Then
+                .BeTrue();
+
+            // Second Identify
+            notCachedEnumIdentifier.Identify(
+                enumIdentifierString,
+                ast
+            ).Should() // Then
+                .BeTrue();
+
+        }
+    }
+}

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/Identifiers/InterfaceResponseTypeIdentifierTests.cs
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/Identifiers/InterfaceResponseTypeIdentifierTests.cs
@@ -1,0 +1,185 @@
+namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Tests.Identifiers
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using EventHorizon.Blazor.TypeScript.Interop.Generator.Identifiers;
+    using EventHorizon.Blazor.TypeScript.Interop.Generator.Model.Statements;
+    using FluentAssertions;
+    using Sdcb.TypeScript;
+    using Xunit;
+
+    public class InterfaceResponseTypeIdentifierTests
+    {
+        [Fact]
+        [Trait("Category", "InterfaceResponseTypeIdentifier.NotCached.StandardUsage")]
+        public void ShouldReturnExpectedIdentificationOfInterfaceWhenUsingNotCachedInstance()
+        {
+            // Given
+            var expected = true;
+            var interfaceIdentifierString = "ExampleInterface";
+
+            var sourceFile = "interface.ts";
+            var source = File.ReadAllText($"./SourceFiles/{sourceFile}");
+            var ast = new TypeScriptAST(source, sourceFile);
+
+            // When
+            var notCachedInterfaceIdentifier = new InterfaceResponseTypeIdentifierNotCached();
+            var actual = notCachedInterfaceIdentifier.Identify(
+                interfaceIdentifierString,
+                ast
+            );
+
+            // Then
+            actual.Should()
+                .Be(expected);
+        }
+
+        [Fact]
+        [Trait("Category", "InterfaceResponseTypeIdentifier.Cached.StandardUsage")]
+        public void ShouldReturnExpectedIdentificationOfInterfaceWhenUsingCachedInstance()
+        {
+            // Given
+            var expected = true;
+            var interfaceIdentifierString = "ExampleInterface";
+
+            var sourceFile = "interface.ts";
+            var source = File.ReadAllText($"./SourceFiles/{sourceFile}");
+            var ast = new TypeScriptAST(source, sourceFile);
+
+            // When
+            var cachedInterfaceIdentifier = new InterfaceResponseTypeIdentifierCached();
+            var actual = cachedInterfaceIdentifier.Identify(
+                interfaceIdentifierString,
+                ast
+            );
+
+            // Then
+            actual.Should()
+                .Be(expected);
+        }
+
+        [Fact]
+        [Trait("Category", "InterfaceResponseTypeIdentifier.Cached.MultipleCalls")]
+        public void ShouldReturnExpectedIdentificationOfInterfaceWhenCalledMultipleTimes()
+        {
+            // Given
+            var interfaceIdentifierString = "ExampleInterface";
+
+            var sourceFile = "interface.ts";
+            var source = File.ReadAllText($"./SourceFiles/{sourceFile}");
+            var ast = new TypeScriptAST(source, sourceFile);
+
+            // When
+            var cachedInterfaceIdentifier = new InterfaceResponseTypeIdentifierCached();
+            // First Identify
+            cachedInterfaceIdentifier.Identify(
+                interfaceIdentifierString,
+                ast
+            ).Should() // Then
+                .BeTrue();
+
+            // Second Identify
+            cachedInterfaceIdentifier.Identify(
+                interfaceIdentifierString,
+                ast
+            ).Should() // Then
+                .BeTrue();
+        }
+
+        [Theory]
+        [Trait("Category", "InterfaceResponseTypeIdentifier.Cached.TypeStatementIdentification")]
+        [InlineData("Random", "ExampleInterface", true, false, false, true)]
+        [InlineData("Random", "ExampleInterface", false, true, false, true)]
+        [InlineData("Random", "ExampleInterface", false, false, true, true)]
+        [InlineData("Random", "ExampleInterface", false, false, false, false)]
+        [InlineData("ExampleInterface", "Other", false, false, false, true)]
+        public void ShouldReturnExpectedIdentificationWhenTypeStatementIsUsed(
+            string typeName,
+            string genericName,
+            bool isModifier,
+            bool isArray,
+            bool isNullable,
+            bool expected
+        )
+        {
+            // Given
+            var type = new TypeStatement
+            {
+                Name = typeName,
+                IsModifier = isModifier,
+                IsArray = isArray,
+                IsNullable = isNullable,
+                GenericTypes = new List<TypeStatement>
+                {
+                    new TypeStatement
+                    {
+                        Name = genericName
+                    }
+                }
+            };
+
+            var sourceFile = "interface.ts";
+            var source = File.ReadAllText($"./SourceFiles/{sourceFile}");
+            var ast = new TypeScriptAST(source, sourceFile);
+
+            // When
+            var cachedInterfaceIdentifier = new InterfaceResponseTypeIdentifierCached();
+            var actual = cachedInterfaceIdentifier.Identify(
+                type,
+                ast
+            );
+
+            // Then
+            actual.Should()
+                .Be(expected);
+        }
+
+        [Theory]
+        [Trait("Category", "InterfaceResponseTypeIdentifier.NotCached.TypeStatementIdentification")]
+        [InlineData("Random", "ExampleInterface", true, false, false, true)]
+        [InlineData("Random", "ExampleInterface", false, true, false, true)]
+        [InlineData("Random", "ExampleInterface", false, false, true, true)]
+        [InlineData("Random", "ExampleInterface", false, false, false, false)]
+        [InlineData("ExampleInterface", "Other", false, false, false, true)]
+        public void ShouldReturnExpectedIdentificationWhenTypeStatementIsUsedAndNotCached(
+            string typeName,
+            string genericName,
+            bool isModifier,
+            bool isArray,
+            bool isNullable,
+            bool expected
+        )
+        {
+            // Given
+            var type = new TypeStatement
+            {
+                Name = typeName,
+                IsModifier = isModifier,
+                IsArray = isArray,
+                IsNullable = isNullable,
+                GenericTypes = new List<TypeStatement>
+                {
+                    new TypeStatement
+                    {
+                        Name = genericName
+                    }
+                }
+            };
+
+            var sourceFile = "interface.ts";
+            var source = File.ReadAllText($"./SourceFiles/{sourceFile}");
+            var ast = new TypeScriptAST(source, sourceFile);
+
+            // When
+            var cachedInterfaceIdentifier = new InterfaceResponseTypeIdentifierNotCached();
+            var actual = cachedInterfaceIdentifier.Identify(
+                type,
+                ast
+            );
+
+            // Then
+            actual.Should()
+                .Be(expected);
+        }
+    }
+}

--- a/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/SourceFiles/enum.ts
+++ b/Tests/EventHorizon.Blazor.TypeScript.Interop.Generator.Tests/SourceFiles/enum.ts
@@ -1,0 +1,3 @@
+export enum EnumExport {
+    VALUE = 0,
+}


### PR DESCRIPTION
Enums used in methods and type response will be transformed to an int.
Split up cache from Interface, now easier to test.
Generated changed to BabylonJS WASM project.