### PR TITLE
Bumped EventHorizon.Blazor.Interop version to 0.1.0-preview0008.

### DIFF
--- a/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/EventHorizon.Blazor.BabylonJS.WASM.csproj
+++ b/Sample/_generated/EventHorizon.Blazor.BabylonJS.WASM/EventHorizon.Blazor.BabylonJS.WASM.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EventHorizon.Blazor.Interop" Version="0.1.0-preview0007" />
+    <PackageReference Include="EventHorizon.Blazor.Interop" Version="0.1.0-preview0008" />
   </ItemGroup>
 
 </Project>

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator.Writers.Project/Templates/ProjectFileTemplate.txt
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator.Writers.Project/Templates/ProjectFileTemplate.txt
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EventHorizon.Blazor.Interop" Version="0.1.0-preview0007" />
+    <PackageReference Include="EventHorizon.Blazor.Interop" Version="0.1.0-preview0008" />
   </ItemGroup>
 
 </Project>

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Identifiers/ActionTypeIdentifier.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Identifiers/ActionTypeIdentifier.cs
@@ -11,11 +11,7 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Identifiers
             string type
         )
         {
-            return type switch
-            {
-                GenerationIdentifiedTypes.Action => true,
-                _ => false,
-            };
+            return GenerationIdentifiedTypes.Action == type;
         }
     }
 }

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Identifiers/TypeIdentifier.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Identifiers/TypeIdentifier.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using EventHorizon.Blazor.TypeScript.Interop.Generator.Model;
-using EventHorizon.Blazor.TypeScript.Interop.Generator.Rules;
 using Sdcb.TypeScript.TsTypes;
 
 namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Identifiers
@@ -38,31 +34,41 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Identifiers
             ClassMetadata classMetadata
         )
         {
-            return kind switch
+            switch (kind)
             {
-                SyntaxKind.UnionType => UnionTypeCheck(
-                    node,
-                    classMetadata
-                ),
-                SyntaxKind.ParenthesizedType => ParenthesizedTypeCheck(
-                    node,
-                    classMetadata
-                ),
-                SyntaxKind.FunctionType => GenerationIdentifiedTypes.Action,
-                SyntaxKind.VoidKeyword => GenerationIdentifiedTypes.Void,
-                SyntaxKind.StringKeyword => GenerationIdentifiedTypes.String,
-                SyntaxKind.BooleanKeyword => GenerationIdentifiedTypes.Bool,
-                SyntaxKind.NumberKeyword => GenerationIdentifiedTypes.Number,
-                SyntaxKind.ObjectKeyword => GenerationIdentifiedTypes.CachedEntity,
-                SyntaxKind.LiteralType => GenerationIdentifiedTypes.Literal,
-                SyntaxKind.TypeLiteral => GenerationIdentifiedTypes.Literal,
-                SyntaxKind.ArrayType => GenerationIdentifiedTypes.Array,
-                // All Other Types
-                _ => AllOtherTypeChecks(
-                    node,
-                    classMetadata
-                ),
-            };
+                case SyntaxKind.UnionType:
+                    return UnionTypeCheck(
+                        node,
+                        classMetadata
+                    );
+                case SyntaxKind.ParenthesizedType:
+                    return ParenthesizedTypeCheck(
+                        node,
+                        classMetadata
+                    );
+                case SyntaxKind.FunctionType:
+                    return GenerationIdentifiedTypes.Action;
+                case SyntaxKind.VoidKeyword:
+                    return GenerationIdentifiedTypes.Void;
+                case SyntaxKind.StringKeyword:
+                    return GenerationIdentifiedTypes.String;
+                case SyntaxKind.BooleanKeyword:
+                    return GenerationIdentifiedTypes.Bool;
+                case SyntaxKind.NumberKeyword:
+                    return GenerationIdentifiedTypes.Number;
+                case SyntaxKind.ObjectKeyword:
+                    return GenerationIdentifiedTypes.CachedEntity;
+                case SyntaxKind.LiteralType:
+                case SyntaxKind.TypeLiteral:
+                    return GenerationIdentifiedTypes.Literal;
+                case SyntaxKind.ArrayType:
+                    return GenerationIdentifiedTypes.Array;
+                default:
+                    return AllOtherTypeChecks(
+                        node,
+                        classMetadata
+                    );
+            }
         }
 
         private static string UnionTypeCheck(

--- a/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Normalizers/DotNetNormalizer.cs
+++ b/Source/EventHorizon.Blazor.TypeScript.Interop.Generator/Normalizers/DotNetNormalizer.cs
@@ -6,21 +6,26 @@ namespace EventHorizon.Blazor.TypeScript.Interop.Generator.Normalizers
 {
     public static class DotNetNormalizer
     {
+        private static readonly IList<string> NORMAILZE_LIST = new List<string>
+        {
+            "ref",
+            "lock",
+            "unlock",
+            "object",
+            "event",
+            "bool",
+            "virtual",
+        };
+
         public static string Normalize(
             string text
         )
         {
-            return text switch
+            if (NORMAILZE_LIST.Contains(text))
             {
-                "ref" => "@ref",
-                "lock" => "@lock",
-                "unlock" => "@unlock",
-                "object" => "@object",
-                "event" => "@event",
-                "bool" => "@bool",
-                "virtual" => "@virtual",
-                _ => text,
-            };
+                return $"@{text}";
+            }
+            return text;
         }
     }
 }


### PR DESCRIPTION
Regenerated BabylonJS WASM project.
Removed expression switch, code coverage not caught correctly with .NET 5.